### PR TITLE
Update CoordConv.py

### DIFF
--- a/CoordConv.py
+++ b/CoordConv.py
@@ -83,8 +83,8 @@ class AddCoords(nn.Module):
         """
         batch_size, _, x_dim, y_dim = input_tensor.size()
 
-        xx_channel = torch.arange(x_dim).repeat(1, y_dim, 1)
-        yy_channel = torch.arange(y_dim).repeat(1, x_dim, 1).transpose(1, 2)
+        xx_channel = torch.arange(x_dim).repeat(1, x_dim, 1).transpose(1, 2)
+        yy_channel = torch.arange(y_dim).repeat(1, y_dim, 1)
 
         xx_channel = xx_channel.float() / (x_dim - 1)
         yy_channel = yy_channel.float() / (y_dim - 1)
@@ -112,7 +112,7 @@ class CoordConv(nn.Module):
     def __init__(self, in_channels, out_channels, with_r=False, **kwargs):
         super().__init__()
         self.addcoords = AddCoords(with_r=with_r)
-        in_size = in_channels+2
+        in_size = in_channels + 2
         if with_r:
             in_size += 1
         self.conv = nn.Conv2d(in_size, out_channels, **kwargs)

--- a/CoordConv.py
+++ b/CoordConv.py
@@ -15,22 +15,22 @@ class AddCoordsTh(nn.Module):
         """
         batch_size_tensor = input_tensor.shape[0]
 
-        xx_ones = torch.ones([1, self.y_dim], dtype=torch.int32)
-        xx_ones = xx_ones.unsqueeze(-1)
+        xx_ones = torch.ones([1, self.x_dim], dtype=torch.int32)
+        xx_ones = xx_ones.unsqueeze(1)
 
         xx_range = torch.arange(self.x_dim, dtype=torch.int32).unsqueeze(0)
-        xx_range = xx_range.unsqueeze(1)
+        xx_range = xx_range.unsqueeze(-1)
 
-        xx_channel = torch.matmul(xx_ones, xx_range)
+        xx_channel = torch.matmul(xx_range, xx_ones)
         xx_channel = xx_channel.unsqueeze(-1)
 
-        yy_ones = torch.ones([1, self.x_dim], dtype=torch.int32)
-        yy_ones = yy_ones.unsqueeze(1)
+        yy_ones = torch.ones([1, self.y_dim], dtype=torch.int32)
+        yy_ones = yy_ones.unsqueeze(-1)
 
         yy_range = torch.arange(self.y_dim, dtype=torch.int32).unsqueeze(0)
-        yy_range = yy_range.unsqueeze(-1)
+        yy_range = yy_range.unsqueeze(1)
 
-        yy_channel = torch.matmul(yy_range, yy_ones)
+        yy_channel = torch.matmul(yy_ones, yy_range)
         yy_channel = yy_channel.unsqueeze(-1)
 
         xx_channel = xx_channel.permute(0, 3, 2, 1)


### PR DESCRIPTION
Fix typo: `x_dim -> y_dim` and exchange `xx_channel` and `yy_channel`.

Comparing with original TF implementation from the paper:
```python
import tensorflow as tf

x_dim = 5
y_dim = 5
batch_size = 2

input_tensor = tf.placeholder(dtype=tf.float32, shape=(batch_size, 1, y_dim, x_dim))

session = tf.InteractiveSession()

batch_size_tensor = tf.shape(input_tensor)[0] 

xx_ones = tf.ones([batch_size_tensor, x_dim], dtype=tf.int32)
xx_ones = tf.expand_dims(xx_ones, -1)
xx_range = tf.tile(tf.expand_dims(tf.range(x_dim), 0),
                  [batch_size_tensor, 1])
xx_range = tf.expand_dims(xx_range, 1)
xx_channel = tf.matmul(xx_ones, xx_range)
xx_channel = tf.expand_dims(xx_channel, -1)

yy_ones = tf.ones([batch_size_tensor, y_dim], dtype=tf.int32)
yy_ones = tf.expand_dims(yy_ones, 1)
yy_range = tf.tile(tf.expand_dims(tf.range(y_dim), 0),
                  [batch_size_tensor, 1])
yy_range = tf.expand_dims(yy_range, -1)
yy_channel = tf.matmul(yy_range, yy_ones)
yy_channel = tf.expand_dims(yy_channel, -1)

xx_channel = tf.cast(xx_channel, "float32") / (x_dim - 1)
yy_channel = tf.cast(yy_channel, "float32") / (y_dim - 1)

xx_channel = xx_channel*2 - 1
yy_channel = yy_channel*2 - 1

np_xx_channel = xx_channel.eval()
print("xx_channel", np_xx_channel.shape)

np_yy_channel = yy_channel.eval()
print("yy_channel", np_yy_channel.shape)

session.close()
```
gives 
```
np_xx_channel[..., 0]
array([[[-1. , -0.5,  0. ,  0.5,  1. ],
        [-1. , -0.5,  0. ,  0.5,  1. ],
        [-1. , -0.5,  0. ,  0.5,  1. ],
        [-1. , -0.5,  0. ,  0.5,  1. ],
        [-1. , -0.5,  0. ,  0.5,  1. ]],

       [[-1. , -0.5,  0. ,  0.5,  1. ],
        [-1. , -0.5,  0. ,  0.5,  1. ],
        [-1. , -0.5,  0. ,  0.5,  1. ],
        [-1. , -0.5,  0. ,  0.5,  1. ],
        [-1. , -0.5,  0. ,  0.5,  1. ]]], dtype=float32)
```
and
```
np_yy_channel[..., 0]
array([[[-1. , -1. , -1. , -1. , -1. ],
        [-0.5, -0.5, -0.5, -0.5, -0.5],
        [ 0. ,  0. ,  0. ,  0. ,  0. ],
        [ 0.5,  0.5,  0.5,  0.5,  0.5],
        [ 1. ,  1. ,  1. ,  1. ,  1. ]],

       [[-1. , -1. , -1. , -1. , -1. ],
        [-0.5, -0.5, -0.5, -0.5, -0.5],
        [ 0. ,  0. ,  0. ,  0. ,  0. ],
        [ 0.5,  0.5,  0.5,  0.5,  0.5],
        [ 1. ,  1. ,  1. ,  1. ,  1. ]]], dtype=float32)
```
However current implementations give inverted results.
